### PR TITLE
Update flake, custom-caddy uses buildGo117Module

### DIFF
--- a/common/default.nix
+++ b/common/default.nix
@@ -78,7 +78,7 @@
         options = [ "NOPASSWD" ];
       }];
     }];
-    nix.trustedUsers = [ "jdheyburn" ];
+    nix.settings.trusted-users = [ "jdheyburn" ];
 
     #############################################################################
     ## Package management
@@ -87,7 +87,7 @@
     # Preserve space by gc-ing and optimising store
     nix.gc.automatic = true;
     nix.gc.options = "--delete-older-than 30d";
-    nix.autoOptimiseStore = true;
+    nix.settings.auto-optimise-store = true;
 
     # Enable flakes
     nix.package = pkgs.nixFlakes;

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
     "argononed": {
       "flake": false,
       "locked": {
-        "lastModified": 1657382323,
-        "narHash": "sha256-CJAc0hUHe2V024GMWuVstzjZKAEu7FsFRX5+vffSkiQ=",
+        "lastModified": 1657851451,
+        "narHash": "sha256-5zGR1jm8niQv8thpdhmNH76rFIkFCvU/sftokd+iaFU=",
         "owner": "DarkElvenAngel",
         "repo": "argononed",
-        "rev": "017a964a19b73bf78bbd5fb41a1dd6295c638a2f",
+        "rev": "aa75305a2d25701a06b61ad47e5d008d7eb97eba",
         "type": "gitlab"
       },
       "original": {
@@ -41,11 +41,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1653594315,
-        "narHash": "sha256-kJ0ENmnQJ4qL2FeYKZba9kvv1KmIuB3NVpBwMeI7AJQ=",
+        "lastModified": 1659725433,
+        "narHash": "sha256-1ZxuK67TL29YLw88vQ18Y2Y6iYg8Jb7I6/HVzmNB6nM=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "184349d8149436748986d1bdba087e4149e9c160",
+        "rev": "41f15759dd8b638e7b4f299730d94d5aa46ab7eb",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -93,11 +93,11 @@
         "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1656367977,
-        "narHash": "sha256-0hV17V9Up9pnAtPJ+787FhrsPnawxoTPA/VxgjRMrjc=",
+        "lastModified": 1660574517,
+        "narHash": "sha256-Lp5D2pAPrM3iAc1eeR0iGwz5rM+SYOWzVxI3p17nlrU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3bf16c0fd141c28312be52945d1543f9ce557bb1",
+        "rev": "688e5c85b7537f308b82167c8eb4ecfb70a49861",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1656933710,
-        "narHash": "sha256-SVG8EqY1OTJWBRY4hpct2ZR2Rk0L8hCFkug3m0ABoZE=",
+        "lastModified": 1660407119,
+        "narHash": "sha256-04lWO0pDbhAXFdL4v2VzzwgxrZ5IefKn+TmZPiPeKxg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3bf48d3587d3f34f745a19ebc968b002ef5b5c5a",
+        "rev": "12620020f76b1b5d2b0e6fbbda831ed4f5fe56e1",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixpkgs-2205": {
       "locked": {
-        "lastModified": 1656754140,
-        "narHash": "sha256-8thJUtZWIimyBtkYQ0tdmmnH0yJvOaw1K5W3OgKc6/A=",
+        "lastModified": 1660496378,
+        "narHash": "sha256-sgAhmrC1iSnl5T2VPPiMpciH1aRw5c7PYEdXX6jd6Gk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "09c32b0bda4db98d6454e910206188e85d5b04cc",
+        "rev": "879121648fe522b38cc1cf75aef160a14a1f2e7b",
         "type": "github"
       },
       "original": {
@@ -171,11 +171,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1656461576,
-        "narHash": "sha256-rlmmw6lIlkMQIiB+NsnO8wQYWTfle8TA41UREPLP5VY=",
+        "lastModified": 1660485612,
+        "narHash": "sha256-sSLW1KaB1adKTJn9+Ja3h3AaS7QCZyhUKiSUStcLg80=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf3ab54b4afe2b7477faa1dd0b65bf74c055d70c",
+        "rev": "6512b21eabb4d52e87ea2edcf31a288e67b2e4f8",
         "type": "github"
       },
       "original": {

--- a/modules/caddy/custom-caddy.nix
+++ b/modules/caddy/custom-caddy.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, buildGoModule, plugins ? [ ], fetchFromGitHub, vendorSha256 ? ""
-}:
+{ stdenv, lib, buildGo117Module, plugins ? [ ], fetchFromGitHub
+, vendorSha256 ? "" }:
 
 with lib;
 
@@ -21,7 +21,7 @@ let
     		}
     	'';
 
-in buildGoModule rec {
+in buildGo117Module rec {
   pname = "caddy";
   version = "2.4.6";
 


### PR DESCRIPTION
Followed these threads for the caddy fix:
- https://discourse.nixos.org/t/unable-to-build-caddy-with-custom-modules/19125/4
- https://github.com/NixOS/nixpkgs/issues/14671