### PR TITLE
Catalog node refactor

### DIFF
--- a/catalog.nix
+++ b/catalog.nix
@@ -4,6 +4,7 @@
 
   nodes = {
     dee = {
+      hostname = "dee";
       ip.private = "192.168.1.10";
       ip.tailscale = "100.127.189.33";
       system = "aarch64-linux";
@@ -12,6 +13,7 @@
     };
 
     dennis = {
+      hostname = "dennis";
       ip.private = "192.168.1.12";
       ip.tailscale = "100.127.102.123";
       system = "x86_64-linux";
@@ -19,18 +21,21 @@
     };
 
     frank = {
+      hostname = "frank";
       ip.private = "192.168.1.11";
       ip.tailscale = "100.71.206.55";
       isNixOS = false;
     };
 
     paddys = {
+      hostname = "paddys";
       ip.private = "192.168.1.20";
       ip.tailscale = "100.107.150.109";
       isNixOS = false;
     };
 
     pve0 = {
+      hostname = "pve0";
       ip.private = "192.168.1.15";
       ip.tailscale = "100.80.112.68";
       isNixOS = false;
@@ -39,7 +44,7 @@
 
   services = {
     adguard = {
-      host = "dee";
+      host = nodes.dee;
       port = 3000;
       caddify.enable = true;
       dashy.section = "networks";
@@ -48,7 +53,7 @@
     };
 
     healthchecks = {
-      host = "dee";
+      host = nodes.dee;
       port = 8000;
       caddify.enable = true;
       dashy.section = "monitoring";
@@ -57,14 +62,14 @@
     };
 
     home = {
-      host = "dennis";
+      host = nodes.dennis;
       port = 4000;
       blackbox.name = "dashy";
       caddify.enable = true;
     };
 
     huginn = {
-      host = "frank";
+      host = nodes.frank;
       port = 3000;
       caddify.enable = true;
       caddify.forwardTo = "dee";
@@ -72,7 +77,7 @@
     };
 
     grafana = {
-      host = "dennis";
+      host = nodes.dennis;
       port = 2342;
       caddify.enable = true;
       dashy.section = "monitoring";
@@ -81,7 +86,7 @@
     };
 
     loki = {
-      host = "dennis";
+      host = nodes.dennis;
       port = 3100;
       blackbox.path = "/ready";
       caddify.enable = true;
@@ -90,14 +95,14 @@
     nodeExporter = { port = 9002; };
 
     minio = {
-      host = "dee";
+      host = nodes.dee;
       port = 9100;
       consolePort = 9101;
       caddify.enable = true;
     };
 
     "ui.minio" = {
-      host = "dee";
+      host = nodes.dee;
       port = services.minio.consolePort;
       caddify.enable = true;
       dashy.section = "storage";
@@ -106,7 +111,7 @@
     };
 
     portainer = {
-      host = "frank";
+      host = nodes.frank;
       port = 9000;
       caddify.enable = true;
       caddify.forwardTo = "dee";
@@ -116,7 +121,7 @@
     };
 
     prometheus = {
-      host = "dennis";
+      host = nodes.dennis;
       port = 9001;
       caddify.enable = true;
       dashy.section = "monitoring";
@@ -127,7 +132,7 @@
     promtail = { port = 28183; };
 
     proxmox = {
-      host = "pve0";
+      host = nodes.pve0;
       port = 8006;
       caddify.enable = true;
       caddify.skip_tls_verify = true;
@@ -138,7 +143,7 @@
     };
 
     plex = {
-      host = "dee";
+      host = nodes.dee;
       port = 32400;
       caddify.enable = true;
       dashy.section = "media";
@@ -147,7 +152,7 @@
     };
 
     thanos-query = {
-      host = "dennis";
+      host = nodes.dennis;
       port = 19192;
       grpcPort = 10902;
       caddify.enable = true;
@@ -167,7 +172,7 @@
     };
 
     unifi = {
-      host = "dee";
+      host = nodes.dee;
       port = 8443;
       caddify.enable = true;
       caddify.skip_tls_verify = true;
@@ -177,7 +182,7 @@
     };
 
     victoriametrics = {
-      host = "dennis";
+      host = nodes.dennis;
       port = 8428;
       caddify.enable = true;
       dashy.section = "monitoring";

--- a/catalog.nix
+++ b/catalog.nix
@@ -2,9 +2,8 @@
 # Inspired from https://github.com/jhillyerd/homelab/blob/main/nixos/catalog.nix
 { nixos-hardware }: rec {
 
-  nodes = {
+  nodesBase = {
     dee = {
-      hostname = "dee";
       ip.private = "192.168.1.10";
       ip.tailscale = "100.127.189.33";
       system = "aarch64-linux";
@@ -13,7 +12,6 @@
     };
 
     dennis = {
-      hostname = "dennis";
       ip.private = "192.168.1.12";
       ip.tailscale = "100.127.102.123";
       system = "x86_64-linux";
@@ -21,26 +19,29 @@
     };
 
     frank = {
-      hostname = "frank";
       ip.private = "192.168.1.11";
       ip.tailscale = "100.71.206.55";
       isNixOS = false;
     };
 
     paddys = {
-      hostname = "paddys";
       ip.private = "192.168.1.20";
       ip.tailscale = "100.107.150.109";
       isNixOS = false;
     };
 
     pve0 = {
-      hostname = "pve0";
       ip.private = "192.168.1.15";
       ip.tailscale = "100.80.112.68";
       isNixOS = false;
     };
   };
+
+  # Enrich nodeBase by adding the key as the hostname - DRY
+  nodes = builtins.listToAttrs (map (hostName: {
+    name = hostName;
+    value = (nodesBase."${hostName}" // { hostName = hostName; });
+  }) (builtins.attrNames nodesBase));
 
   services = {
     adguard = {
@@ -72,7 +73,7 @@
       host = nodes.frank;
       port = 3000;
       caddify.enable = true;
-      caddify.forwardTo = "dee";
+      caddify.forwardTo = nodes.dee;
       dashy.icon = "hl-huginn";
     };
 
@@ -114,7 +115,7 @@
       host = nodes.frank;
       port = 9000;
       caddify.enable = true;
-      caddify.forwardTo = "dee";
+      caddify.forwardTo = nodes.dee;
       dashy.section = "virtualisation";
       dashy.description = "Frontend for containers";
       dashy.icon = "hl-portainer";
@@ -136,7 +137,7 @@
       port = 8006;
       caddify.enable = true;
       caddify.skip_tls_verify = true;
-      caddify.forwardTo = "dee";
+      caddify.forwardTo = nodes.dee;
       dashy.section = "virtualisation";
       dashy.description = "Frontend for VMs";
       dashy.icon = "hl-proxmox";

--- a/modules/caddy/default.nix
+++ b/modules/caddy/default.nix
@@ -46,8 +46,8 @@ let
   # Filters out any services destined for this host, where we want it caddified
   # TODO should it also depend whether the module is enabled or not?
   host_services = (filterAttrs (n: v:
-    v ? "host" && v.host == config.networking.hostName && v.caddify.enable)
-    catalog.services);
+    v ? "host" && v.host.hostName == config.networking.hostName
+    && v.caddify.enable) catalog.services);
 
   # Convert host_routes to a list, including the name of the service in it too
   host_services_list = map
@@ -67,7 +67,8 @@ let
   # These are additional services that this host should forward
   forward_services = (filterAttrs (n: v:
     v ? "caddify" && v.caddify ? "forwardTo" && v.caddify.enable
-    && v.caddify.forwardTo == config.networking.hostName) catalog.services);
+    && v.caddify.forwardTo.hostName == config.networking.hostName)
+    catalog.services);
 
   # Convert it to a list
   forward_services_list = map (service_name:
@@ -79,7 +80,7 @@ let
     route {
       name = service.name;
       port = service.port;
-      upstream = catalog.nodes."${service.host}".ip.private;
+      upstream = service.host.ip.private;
       skip_tls_verify = service.caddify ? "skip_tls_verify"
         && service.caddify.skip_tls_verify;
       # Not supporting paths yet since I don't have a scenario to test it on

--- a/modules/dns/default.nix
+++ b/modules/dns/default.nix
@@ -15,22 +15,17 @@ let
     (service_name: caddy_services."${service_name}" // { name = service_name; })
     (attrNames caddy_services);
 
-  # get_forward_to_node = service:
-  #   if service.caddify ? "forwardTo" then
-  #     catalog.nodes."${service.caddify.forwardTo}"
-  #   else
-  #     catalog.nodes."${service.host}";
-
-  # # Add the IP address for the host the service is on
-  # caddy_host_services =
-  #   map (service: service // { ip = (get_forward_to_node service).ip.private; })
-  #   caddy_services_list;
+  getCaddyDestination = service:
+    if service.caddify ? "forwardTo" then
+      service.caddify.forwardTo
+    else
+      service.host;
 
   # For each service create a list of rewrites
   rewrites = map (service: {
     domain = "${service.name}.svc.joannet.casa";
-    answer = service.host.ip.private;
-  }) caddy_host_services;
+    answer = (getCaddyDestination service).ip.private;
+  }) caddy_services_list;
 
 in {
 

--- a/modules/dns/default.nix
+++ b/modules/dns/default.nix
@@ -15,21 +15,21 @@ let
     (service_name: caddy_services."${service_name}" // { name = service_name; })
     (attrNames caddy_services);
 
-  get_forward_to_node = service:
-    if service.caddify ? "forwardTo" then
-      catalog.nodes."${service.caddify.forwardTo}"
-    else
-      catalog.nodes."${service.host}";
+  # get_forward_to_node = service:
+  #   if service.caddify ? "forwardTo" then
+  #     catalog.nodes."${service.caddify.forwardTo}"
+  #   else
+  #     catalog.nodes."${service.host}";
 
-  # Add the IP address for the host the service is on
-  caddy_host_services =
-    map (service: service // { ip = (get_forward_to_node service).ip.private; })
-    caddy_services_list;
+  # # Add the IP address for the host the service is on
+  # caddy_host_services =
+  #   map (service: service // { ip = (get_forward_to_node service).ip.private; })
+  #   caddy_services_list;
 
   # For each service create a list of rewrites
   rewrites = map (service: {
     domain = "${service.name}.svc.joannet.casa";
-    answer = service.ip;
+    answer = service.host.ip.private;
   }) caddy_host_services;
 
 in {


### PR DESCRIPTION
- Removed the text lookups for service.host and service.caddify.forwardTo
- Replaced with references to the node definitions