### PR TITLE
Adguard uses port from catalog

### DIFF
--- a/modules/dns/default.nix
+++ b/modules/dns/default.nix
@@ -52,6 +52,7 @@ in {
         "--no-etc-hosts"
       ];
       settings = {
+        bind_port = catalog.services.adguard.port;
         users = [{
           name = "admin";
           password =


### PR DESCRIPTION
It was already set to the default (3000) but add the setting here for consistency.