### PR TITLE
Refactor service base

### DIFF
--- a/modules/dashy/default.nix
+++ b/modules/dashy/default.nix
@@ -49,7 +49,7 @@ let
         icon = service.dashy.icon;
       }) services;
     sectionItems = sectionName:
-      createSectionItems (lib.attrsets.attrValues (filterAttrs
+      createSectionItems (attrValues (filterAttrs
         (svc_name: svc_def: isDashyService (toLower sectionName) svc_def)
         catalog.services));
   in map (section: section // { items = sectionItems section.name; }) sections;

--- a/modules/dns/default.nix
+++ b/modules/dns/default.nix
@@ -6,14 +6,9 @@ let
   cfg = config.modules.dns;
 
   # Get services which are being served by caddy
-  caddy_services = filterAttrs
-    (n: v: v ? "caddify" && v.caddify ? "enable" && v.caddify.enable)
-    catalog.services;
-
-  # Convert it to a list
-  caddy_services_list = map
-    (service_name: caddy_services."${service_name}" // { name = service_name; })
-    (attrNames caddy_services);
+  caddy_services = attrValues (filterAttrs (svc_name: svc_def:
+    svc_def ? "caddify" && svc_def.caddify ? "enable" && svc_def.caddify.enable)
+    catalog.services);
 
   getCaddyDestination = service:
     if service.caddify ? "forwardTo" then
@@ -25,7 +20,7 @@ let
   rewrites = map (service: {
     domain = "${service.name}.svc.joannet.casa";
     answer = (getCaddyDestination service).ip.private;
-  }) caddy_services_list;
+  }) caddy_services;
 
 in {
 

--- a/modules/prometheus-stack/scrape-configs.nix
+++ b/modules/prometheus-stack/scrape-configs.nix
@@ -10,17 +10,18 @@ let
     (svc_name: svc_def: svc_def ? "caddify" && svc_def.caddify.enable)
     catalog.services);
 
-  internal_https_targets = map (service:
-    "https://${service.name}.svc.joannet.casa${
-      if service ? "blackbox" && service.blackbox ? "path" then
-        service.blackbox.path
-      else
-        ""
-    };${
+  internal_https_targets = let
+    getPath = service:
+      optionalString (service ? "blackbox" && service.blackbox ? "path")
+      service.blackbox.path;
+    getHumanName = service:
       if service ? "blackbox" && service.blackbox ? "name" then
         service.blackbox.name
       else
-        service.name
+        service.name;
+  in map (service:
+    "https://${service.name}.svc.joannet.casa${getPath service};${
+      getHumanName service
     };internal") caddified_services;
 
   external_targets = map (url: "https://${url};${url};external") [


### PR DESCRIPTION
- Since #40 introduced enriching of serviceName to services by default, we don't need each module to enrich it itself
- We already did something similar for nodes and nodeBase in #35
- I also tidied up internal_https_target to use optionalString