### PR TITLE
Upgrade Loki db to tsdb

### DIFF
--- a/modules/prometheus-stack/loki.nix
+++ b/modules/prometheus-stack/loki.nix
@@ -34,16 +34,28 @@ in {
     };
 
     schema_config = {
-      configs = [{
-        from = "2020-10-24";
-        store = "boltdb-shipper";
-        object_store = "filesystem";
-        schema = "v11";
-        index = {
-          prefix = "index_";
-          period = "24h";
-        };
-      }];
+      configs = [
+        {
+          from = "2020-10-24";
+          store = "boltdb-shipper";
+          object_store = "filesystem";
+          schema = "v11";
+          index = {
+            prefix = "index_";
+            period = "24h";
+          };
+        }
+        {
+          from = "2023-03-08";
+          store = "tsdb";
+          object_store = "filesystem";
+          schema = "v12";
+          index = {
+            prefix = "tsdb_index_";
+            period = "24h";
+          };
+        }
+      ];
     };
 
     storage_config = {

--- a/modules/prometheus-stack/loki.nix
+++ b/modules/prometheus-stack/loki.nix
@@ -46,12 +46,12 @@ in {
           };
         }
         {
-          from = "2023-03-08";
+          from = "2023-03-09";
           store = "tsdb";
           object_store = "filesystem";
           schema = "v12";
           index = {
-            prefix = "tsdb_index_";
+            prefix = "index_";
             period = "24h";
           };
         }
@@ -62,6 +62,13 @@ in {
       boltdb_shipper = {
         active_index_directory = "${lokiDir}/boltdb-shipper-active";
         cache_location = "${lokiDir}/boltdb-shipper-cache";
+        # Can be increased for faster performance over longer query periods, uses more disk space
+        cache_ttl = "24h";
+        shared_store = "filesystem";
+      };
+      tsdb_shipper = {
+        active_index_directory = "${lokiDir}/tsdb-index";
+        cache_location = "${lokiDir}/tsdb-cache";
         # Can be increased for faster performance over longer query periods, uses more disk space
         cache_ttl = "24h";
         shared_store = "filesystem";


### PR DESCRIPTION
Guides: 
- https://grafana.com/blog/2022/12/01/grafana-loki-2.7-release/?pg=blog&plcmt=body-txt
- https://github.com/owen-d/loki/blob/49212f534eb59c48cd041bf0751d8fd8dd052ae4/docs/sources/operations/storage/tsdb.md