### PR TITLE
Add ssh config to home-manager

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,8 @@
           modules = [
             ./home/common.nix
             ./home/users/jdheyburn
+            # This is just for paddys
+            ./home/roles/desktop
           ];
         };
 

--- a/home/roles/desktop/default.nix
+++ b/home/roles/desktop/default.nix
@@ -1,0 +1,44 @@
+{ pkgs, ... }:
+
+let
+  tmuxSettings = {
+    RequestTTY = "yes";
+    RemoteCommand = "tmux new-session -A -s ssh_tmux";
+  };
+in {
+  home.packages = with pkgs; [
+    obsidian
+  ];
+
+  # SSH client related stuff here, I only want this on paddys (laptop)
+  services.ssh-agent.enable = true;
+  programs.ssh = {
+      enable = true;
+      matchBlocks = {
+        charlie = {
+          extraOptions = tmuxSettings;
+        };
+        charlie-no-tmux = {
+          hostname = "charlie";
+        };
+        dee = {
+          extraOptions = tmuxSettings;
+        };
+        dee-no-tmux = {
+          hostname = "dee";
+        };
+        dennis = {
+          extraOptions = tmuxSettings;
+        };
+        dennis-no-tmux = {
+          hostname = "dennis";
+        };
+        "gitlab.com" = {
+          user = "git";
+        };
+        "github.com" = {
+          user = "git";
+        };
+      };
+    };
+}

--- a/home/roles/server/default.nix
+++ b/home/roles/server/default.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }:
+{
+    # Empty for now
+}

--- a/home/users/jdheyburn/default.nix
+++ b/home/users/jdheyburn/default.nix
@@ -1,47 +1,5 @@
-{ config, pkgs, ... }:
-
-let
-  tmuxSettings = {
-    RequestTTY = "yes";
-    RemoteCommand = "tmux new-session -A -s ssh_tmux";
-  };
-in {
+{ pkgs, ... }:
+{
   home.username = "jdheyburn";
   home.homeDirectory = "/home/jdheyburn";
-
-  home.packages = with pkgs; [
-    obsidian
-  ];
-
-  services.ssh-agent.enable = true;
-
-  programs.ssh = {
-      enable = true;
-      matchBlocks = {
-        charlie = {
-          extraOptions = tmuxSettings;
-        };
-        charlie-no-tmux = {
-          hostname = "charlie";
-        };
-        dee = {
-          extraOptions = tmuxSettings;
-        };
-        dee-no-tmux = {
-          hostname = "dee";
-        };
-        dennis = {
-          extraOptions = tmuxSettings;
-        };
-        dennis-no-tmux = {
-          hostname = "dennis";
-        };
-        "gitlab.com" = {
-          user = "git";
-        };
-        "github.com" = {
-          user = "git";
-        };
-      };
-    };
 }

--- a/home/users/jdheyburn/default.nix
+++ b/home/users/jdheyburn/default.nix
@@ -1,10 +1,51 @@
 { config, pkgs, ... }:
 
-{
+let
+  tmuxSettings = {
+    RequestTTY = "yes";
+    RemoteCommand = "tmux new-session -A -s ssh_tmux";
+  };
+in {
   home.username = "jdheyburn";
   home.homeDirectory = "/home/jdheyburn";
 
   home.packages = with pkgs; [
     obsidian
   ];
+
+  services.ssh-agent.enable = true;
+
+  programs.ssh = {
+      enable = true;
+      matchBlocks = {
+        charlie = {
+          extraOptions = tmuxSettings;
+        };
+        charlie-no-tmux = {
+          hostname = "charlie";
+        };
+        dee = {
+          extraOptions = tmuxSettings;
+        };
+        dee-no-tmux = {
+          hostname = "dee";
+        };
+        dennis = {
+          extraOptions = tmuxSettings;
+        };
+        dennis-no-tmux = {
+          hostname = "dennis";
+        };
+        "gitlab.com" = {
+          user = "git";
+          # TODO change for generic
+          identityFile = "~/.ssh/gitlab-personal-paddys";
+        };
+        "github.com" = {
+          user = "git";
+          # TODO change for generic
+          identityFile = "~/.ssh/id_ed25519_github";
+        };
+      };
+    };
 }

--- a/home/users/jdheyburn/default.nix
+++ b/home/users/jdheyburn/default.nix
@@ -38,13 +38,9 @@ in {
         };
         "gitlab.com" = {
           user = "git";
-          # TODO change for generic
-          identityFile = "~/.ssh/gitlab-personal-paddys";
         };
         "github.com" = {
           user = "git";
-          # TODO change for generic
-          identityFile = "~/.ssh/id_ed25519_github";
         };
       };
     };


### PR DESCRIPTION
- Created new "role" grouping, as I don't want ssh config going to servers
- It also removes the problem of Obsidian being installed on servers
