### PR TITLE
Disable zsh magic functions

### DIFF
--- a/home/common.nix
+++ b/home/common.nix
@@ -271,6 +271,12 @@
       SUDO_EDITOR = "nvim";
     };
 
+    # This is executed before plugins such as oh-my-zsh are called
+    initExtraBeforeCompInit = ''
+      # Stops escaping URL characters, slow copy-paste, etc.
+      DISABLE_MAGIC_FUNCTIONS=true
+    '';
+
     initExtra = ''
       ${builtins.readFile ./dotfiles/zsh-initExtra-kubectl_aliases.zsh}
       ${builtins.readFile ./dotfiles/zsh-initExtra-functions.zsh}


### PR DESCRIPTION
When I copy paste URLs, they appear slow and zsh escapes characters for some reason.

This is a pain for when I want to `wget` something, and the escaped special chars in the URL cause the command to fail.

Source: https://stackoverflow.com/questions/25614613/how-to-disable-zsh-substitution-autocomplete-with-url-and-backslashes