### PR TITLE
Use delta as a git differ

### DIFF
--- a/home/common.nix
+++ b/home/common.nix
@@ -38,11 +38,19 @@
     userEmail = "jdheyburn@gmail.com";
     extraConfig = {
       # Configs related to delta as a differ
+      blame.pager = "${pkgs.delta}/bin/delta";
       core.pager = "${pkgs.delta}/bin/delta";
       interative.diffFilter = "${pkgs.delta}/bin/delta --color-only --features=interactive";
-      delta.navigate = true;
-      delta.light = false;
-      delta.line-numbers = true;
+      delta = {
+        # creates links to the git commit in upstream repo
+        hyperlinks = true;
+        # Not sure if this works as intended: https://dandavison.github.io/delta/tips-and-tricks/using-delta-with-vscode.html
+        hyperlinks-file-link-format = "vscode://file/{path}:{line}";
+        light = false;
+        line-numbers = true;
+        # navigate allows skipping to next/previous file with n/N respectively
+        navigate = true;
+      };
       merge.conflictstyle = "diff3";
       diff.colorMoved = "default";
 

--- a/home/common.nix
+++ b/home/common.nix
@@ -6,6 +6,7 @@
   home.stateVersion = "22.05";
 
   home.packages = with pkgs; [
+    delta
     diff-so-fancy
     dyff
   ];
@@ -22,13 +23,29 @@
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;
 
+  # This does take over the whole bat/themes directory, whereas I only
+  # need the *.tmTheme files from it. For now this does the job.
+  home.file.".config/bat/themes".source = pkgs.fetchFromGitHub {
+    owner = "catppuccin";
+    repo = "bat";
+    rev = "ba4d16880d63e656acced2b7d4e034e4a93f74b1";
+    sha256 = "sha256-6WVKQErGdaqb++oaXnY3i6/GuH2FhTgK0v4TN4Y0Wbw=";
+  };
+
   programs.git = {
     enable = true;
     userName = "Joseph Heyburn";
     userEmail = "jdheyburn@gmail.com";
     extraConfig = {
-      core.pager =
-        "${pkgs.diff-so-fancy}/bin/diff-so-fancy | less --tabs=4 -RFX";
+      # Configs related to delta as a differ
+      core.pager = "${pkgs.delta}/bin/delta";
+      interative.diffFilter = "${pkgs.delta}/bin/delta --color-only --features=interactive";
+      delta.navigate = true;
+      delta.light = false;
+      delta.line-numbers = true;
+      merge.conflictstyle = "diff3";
+      diff.colorMoved = "default";
+
       init.defaultBranch = "main";
       pull.rebase = "false";
       push.autoSetupRemote = "true";
@@ -269,7 +286,11 @@
       YC = "-o yaml | cat";
     };
 
-    localVariables = {
+    # sessionVariables get prefixed with `export`
+    # localVariables do not
+    sessionVariables = {
+      BAT_THEME = "Catppuccin-macchiato";
+      DELTA_PAGER = "less --tabs=4 --RAW-CONTROL-CHARS --no-init --quit-if-one-screen";
       EDITOR = "nvim";
       SUDO_EDITOR = "nvim";
     };

--- a/home/users/joseph.heyburn/default.nix
+++ b/home/users/joseph.heyburn/default.nix
@@ -227,6 +227,12 @@ in
       "terminal.integrated.copyOnSelection" = true;
       # Auto-open zsh in the terminal
       "terminal.integrated.defaultProfile.osx" = "zsh";
+      # Required so that zshenv (read: programs.zsh.sessionVariables) get loaded
+      # e.g. BAT_THEME, which is used by git differ "delta" for syntax highlighting
+      "terminal.integrated.profiles.osx".zsh = {
+        path = "zsh";
+        args = [ "-l" "-i" ];
+      };
       "terminal.integrated.enableMultiLinePasteWarning" = false;
       "terminal.integrated.fontFamily" = "'MesloLGS NF', 'Meslo LG M DZ for Powerline', monospace";
       "terminal.integrated.fontSize" = 12;


### PR DESCRIPTION
I came across [delta](https://github.com/dandavison/delta), so I wanted to replace it with [diff-so-easy](https://github.com/so-fancy/diff-so-fancy) for my git diffs as it seems more [feature rich](https://dandavison.github.io/delta/features.html).

The flow went like this:
- Add delta to gitconfig
- I saw that delta uses [bat](https://github.com/sharkdp/bat) for syntax highlighting, which I'm already using as a cat replacement
- I saw there is a [Catpuccin theme for bat](https://github.com/catppuccin/bat) I already have Catpuccin as a theme for other apps
- Install Catpuccin themes to `.config/bat/themes`
- Set `BAT_THEME` in my `localVariables`
- Discovered that `localVariables` does not get exported, so change them to `sessionVariables` - this moves them from `.zshrc` to `.zshenv`
- Found that `sessionVariables` (via `.zshenv`) were not being loaded in VSCode terminal
  - https://github.com/nix-community/home-manager/commit/2116fe6b50a5118d56f1f443cccf024abee9de40
  - https://github.com/nix-community/home-manager/issues/2751
- Adjust VSCode terminal to specify the shell as an interactive login shell
  - https://stackoverflow.com/questions/70409788/vscode-terminal-not-loading-zshrc-on-startup-how-can-i-fix-this