### PR TITLE
Simplify Caddy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,28 +26,19 @@ Services is a mapping of service name to service attributes, it can accept:
   - The node that runs this service
 - `port`
   - Port this service runs on
-- `caddify.enable`
-  - Whether Caddy configs should be created
-  - Also used by DNS module to create a rewrite entry
-- `caddify.skip_tls_verify`
-  - Whether Caddy should ignore TLS verification when forwarding traffic to this service
-  - Usually for when the backend service is on HTTPS, and I cba to set up certificate trust
-- `caddify.forwardTo`
-  - Define a node name here different to host to have that node set up reverse proxy instead
-  - Currently I'm using this to reverse proxy for services where nodes do not have Caddy on them (i.e. non-NixOS nodes)
-- `caddify.paths`
-  - A list of paths, additional path forwarding to ports that
-  - Used this for testing path forwarding for minio console, reverted as it didn't play nice
-  - `path`
-    - The URL path to forward (e.g. `/ui/*`)
-  - `port`
-    - The port to forward to
+- `dns.enable`
+  - Whether a DNS rewrite entry should be created on the DNS server
+  - i.e. gives the service a `$SERVICE.svc.joannet.casa` hostname
 - `dashy.section`
   - What section in dashy it should fall under
 - `dashy.description`
   - The description to use in dashy
 - `dashy.icon`
   - The icon to display in dashy
+- `blackbox.name`
+  - Whether the service name in healthchecks differs from the DNS name
+- `blackbox.path`
+  - The path that blackbox healthchecks should use, if it differs from root `/`
 
 ## Hosts
 
@@ -58,6 +49,21 @@ Services is a mapping of service name to service attributes, it can accept:
   - VM on a Proxmox hypervisor
 - macbook
   - MBP with nix-darwin
+
+Hosts are defined in `nodes`, which can have these attributes:
+
+- `ip.private`
+  - Private IP address
+- `ip.tailscale`
+  - IP address as tailscale sees it
+- `domain`
+  - If the host is on an 'external' domain to the homelab
+- `shouldScrape`
+  - If Prometheus should scrape this node for metrics
+  - This is only temporary while I decom the non-NixOS hosts
+- `isNixOS`
+  - Whether this node is on NixOS or not
+  - Infers some properties about the node
 
 ## Runbooks
 

--- a/catalog.nix
+++ b/catalog.nix
@@ -55,10 +55,10 @@
     adguard = {
       host = nodes.dee;
       port = 3000;
-      caddify.enable = true;
       dashy.section = "networks";
       dashy.description = "DNS resolver";
       dashy.icon = "hl-adguardhome";
+      dns.enable = true;
     };
 
     blackboxExporter = { port = 9115; };
@@ -66,41 +66,41 @@
     healthchecks = {
       host = nodes.dee;
       port = 8000;
-      caddify.enable = true;
       dashy.section = "monitoring";
       dashy.description = "Monitor status of cron jobs";
       dashy.icon = "hl-healthchecks";
+      dns.enable = true;
     };
 
     home = {
       host = nodes.dennis;
       port = 4000;
       blackbox.name = "dashy";
-      caddify.enable = true;
+      dns.enable = true;
     };
 
     huginn = {
       host = nodes.frank;
       port = 3000;
-      caddify.enable = true;
       caddify.forwardTo = nodes.dee;
       dashy.icon = "hl-huginn";
+      dns.enable = false;
     };
 
     grafana = {
       host = nodes.dennis;
       port = 2342;
-      caddify.enable = true;
       dashy.section = "monitoring";
       dashy.description = "View logs and metrics";
       dashy.icon = "hl-grafana";
+      dns.enable = true;
     };
 
     loki = {
       host = nodes.dennis;
       port = 3100;
       blackbox.path = "/ready";
-      caddify.enable = true;
+      dns.enable = true;
     };
 
     nodeExporter = { port = 9002; };
@@ -109,67 +109,65 @@
       host = nodes.dee;
       port = 9100;
       consolePort = 9101;
-      caddify.enable = true;
+      dns.enable = true;
     };
 
     "ui.minio" = {
       host = nodes.dee;
       port = services.minio.consolePort;
-      caddify.enable = true;
       dashy.section = "storage";
       dashy.description = "S3 compatible object storage";
       dashy.icon = "hl-minio";
+      dns.enable = true;
     };
 
     portainer = {
       host = nodes.frank;
       port = 9000;
-      caddify.enable = true;
       caddify.forwardTo = nodes.dee;
       dashy.section = "virtualisation";
       dashy.description = "Frontend for containers";
       dashy.icon = "hl-portainer";
+      dns.enable = false;
     };
 
     prometheus = {
       host = nodes.dennis;
       port = 9001;
-      caddify.enable = false;
       dashy.section = "monitoring";
       dashy.description = "Polls for metrics before captured by Thanos";
       dashy.icon = "hl-prometheus";
+      dns.enable = false;
     };
 
     promtail = { port = 28183; };
 
     proxmox = {
-      host = nodes.pve0;
+      host = nodes.dee;
       port = 8006;
-      caddify.enable = true;
-      caddify.skip_tls_verify = true;
-      caddify.forwardTo = nodes.dee;
       dashy.section = "virtualisation";
       dashy.description = "Frontend for VMs";
       dashy.icon = "hl-proxmox";
+      dns.enable = true;
     };
 
     plex = {
       host = nodes.dee;
       port = 32400;
-      caddify.enable = true;
       dashy.section = "media";
       dashy.description = "Watch TV and movies";
       dashy.icon = "hl-plex";
+      dns.enable = true;
     };
 
     thanos-query = {
       host = nodes.dennis;
       port = 19192;
       grpcPort = 10902;
-      caddify.enable = false;
       dashy.section = "monitoring";
       dashy.description = "Long term storage for Prometheus metrics";
       dashy.icon = "hl-thanos";
+      dns.enable = false;
     };
 
     thanos-sidecar = {
@@ -185,20 +183,20 @@
     unifi = {
       host = nodes.dennis;
       port = 8443;
-      caddify.enable = true;
       caddify.skip_tls_verify = true;
       dashy.section = "networks";
       dashy.description = "UniFi controller";
       dashy.icon = "hl-unifi-controller";
+      dns.enable = true;
     };
 
     victoriametrics = {
       host = nodes.dennis;
       port = 8428;
-      caddify.enable = true;
       dashy.section = "monitoring";
       dashy.description = "Alternate poller of metrics in PromQL format";
       dashy.icon = "https://avatars.githubusercontent.com/u/43720803";
+      dns.enable = true;
     };
   };
 

--- a/catalog.nix
+++ b/catalog.nix
@@ -4,9 +4,11 @@
 
   nodesBase = {
     charlie = {
-      ip.private = "128.140.63.95";
+      ip.tailscale = "100.74.217.71";
+      domain = "bishop-beardie.ts.net";
       system = "x86_64-linux";
       isNixOS = true;
+      shouldScrape = true;
     };
 
     dee = {
@@ -15,6 +17,7 @@
       system = "aarch64-linux";
       isNixOS = true;
       nixosHardware = nixos-hardware.nixosModules.raspberry-pi-4;
+      shouldScrape = true;
     };
 
     dennis = {
@@ -22,24 +25,28 @@
       ip.tailscale = "100.127.102.123";
       system = "x86_64-linux";
       isNixOS = true;
+      shouldScrape = true;
     };
 
     frank = {
       ip.private = "192.168.1.11";
       ip.tailscale = "100.71.206.55";
       isNixOS = false;
+      shouldScrape = false;
     };
 
     paddys = {
       ip.private = "192.168.1.20";
       ip.tailscale = "100.107.150.109";
       isNixOS = false;
+      shouldScrape = true;
     };
 
     pve0 = {
       ip.private = "192.168.1.15";
       ip.tailscale = "100.80.112.68";
       isNixOS = false;
+      shouldScrape = false;
     };
   };
 
@@ -82,7 +89,6 @@
     huginn = {
       host = nodes.frank;
       port = 3000;
-      caddify.forwardTo = nodes.dee;
       dashy.icon = "hl-huginn";
       dns.enable = false;
     };
@@ -124,7 +130,6 @@
     portainer = {
       host = nodes.frank;
       port = 9000;
-      caddify.forwardTo = nodes.dee;
       dashy.section = "virtualisation";
       dashy.description = "Frontend for containers";
       dashy.icon = "hl-portainer";
@@ -183,7 +188,6 @@
     unifi = {
       host = nodes.dennis;
       port = 8443;
-      caddify.skip_tls_verify = true;
       dashy.section = "networks";
       dashy.description = "UniFi controller";
       dashy.icon = "hl-unifi-controller";

--- a/flake.lock
+++ b/flake.lock
@@ -4,14 +4,15 @@
       "inputs": {
         "darwin": "darwin",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1696775529,
-        "narHash": "sha256-TYlE4B0ktPtlJJF9IFxTWrEeq+XKG8Ny0gc2FGEAdj0=",
+        "lastModified": 1703433843,
+        "narHash": "sha256-nmtA4KqFboWxxoOAA6Y1okHbZh+HsXaMPFkYHsoDRDw=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "daf42cb35b2dc614d1551e37f96406e4c4a2d3e4",
+        "rev": "417caa847f9383e111d1397039c9d4337d024bf0",
         "type": "github"
       },
       "original": {
@@ -44,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673295039,
-        "narHash": "sha256-AsdYgE8/GPwcelGgrntlijMg4t3hLFJFCRF3tL5WVjA=",
+        "lastModified": 1700795494,
+        "narHash": "sha256-gzGLZSiOhf155FW7262kdHo2YDeugp3VuIFb4/GGng0=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "87b9d090ad39b25b2400029c64825fc2a8868943",
+        "rev": "4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d",
         "type": "github"
       },
       "original": {
@@ -65,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700795494,
-        "narHash": "sha256-gzGLZSiOhf155FW7262kdHo2YDeugp3VuIFb4/GGng0=",
+        "lastModified": 1704277720,
+        "narHash": "sha256-meAKNgmh3goankLGWqqpw73pm9IvXjEENJloF0coskE=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d",
+        "rev": "0dd382b70c351f528561f71a0a7df82c9d2be9a4",
         "type": "github"
       },
       "original": {
@@ -85,11 +86,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1698921442,
-        "narHash": "sha256-7KmvhQ7FuXlT/wG4zjTssap6maVqeAMBdtel+VjClSM=",
+        "lastModified": 1704875591,
+        "narHash": "sha256-eWRLbqRcrILgztU/m/k7CYLzETKNbv0OsT2GjkaNm8A=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "660180bbbeae7d60dad5a92b30858306945fd427",
+        "rev": "1776009f1f3fb2b5d236b84d9815f2edee463a9b",
         "type": "github"
       },
       "original": {
@@ -101,11 +102,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -116,14 +117,14 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -140,11 +141,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682203081,
-        "narHash": "sha256-kRL4ejWDhi0zph/FpebFYhzqlOBrk0Pl3dzGEKSAlEw=",
+        "lastModified": 1703113217,
+        "narHash": "sha256-7ulcXOk63TIT2lVDSExj7XzFx09LpdSAPtvgtM7yQPE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "32d3e39c491e2f91152c84f8ad8b003420eab0a1",
+        "rev": "3bfaacf46133c037bb356193bd2f1765d9dc82c1",
         "type": "github"
       },
       "original": {
@@ -160,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701071203,
-        "narHash": "sha256-lQywA7QU/vzTdZ1apI0PfgCWNyQobXUYghVrR5zuIeM=",
+        "lastModified": 1705169127,
+        "narHash": "sha256-j9OEtNxOIPWZWjbECVMkI1TO17SzlpHMm0LnVWKOR/g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "db1878f013b52ba5e4034db7c1b63e8d04173a86",
+        "rev": "f2942f3385f1b35cc8a1abb03a45e29c9cb4d3c8",
         "type": "github"
       },
       "original": {
@@ -175,11 +176,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1701020860,
-        "narHash": "sha256-NwnRn04C8s+hH+KdVtGmVB1FFNIG7DtPJmQSCBDaET4=",
+        "lastModified": 1705187059,
+        "narHash": "sha256-dSj+iIYqLA+7/5rLXWfUxw9IXRm0w8Mrm39af8klUH0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b006ec52fce23b1d57f6ab4a42d7400732e9a0a2",
+        "rev": "ef811636cc847355688804593282078bac7758d4",
         "type": "github"
       },
       "original": {
@@ -191,11 +192,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677676435,
-        "narHash": "sha256-6FxdcmQr5JeZqsQvfinIMr0XcTyTuR7EXX0H3ANShpQ=",
+        "lastModified": 1703013332,
+        "narHash": "sha256-+tFNwMvlXLbJZXiMHqYq77z/RfmpfpiI3yjL6o/Zo9M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a08d6979dd7c82c4cef0dcc6ac45ab16051c1169",
+        "rev": "54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6",
         "type": "github"
       },
       "original": {
@@ -207,11 +208,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1700794826,
-        "narHash": "sha256-RyJTnTNKhO0yqRpDISk03I/4A67/dp96YRxc86YOPgU=",
+        "lastModified": 1705133751,
+        "narHash": "sha256-rCIsyE80jgiOU78gCWN3A0wE0tR2GI5nH6MlS+HaaSQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a09cb4b393d58f9ed0d9ca1555016a8543c2ac8",
+        "rev": "9b19f5e77dd906cb52dade0b7bd280339d2a1f3d",
         "type": "github"
       },
       "original": {
@@ -223,11 +224,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1671417167,
-        "narHash": "sha256-JkHam6WQOwZN1t2C2sbp1TqMv3TVRjzrdoejqfefwrM=",
+        "lastModified": 1702272962,
+        "narHash": "sha256-D+zHwkwPc6oYQ4G3A1HuadopqRwUY/JkMwHz1YF7j4Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bb31220cca6d044baa6dc2715b07497a2a7c4bc7",
+        "rev": "e97b3e4186bcadf0ef1b6be22b8558eab1cdeb5d",
         "type": "github"
       },
       "original": {
@@ -244,11 +245,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700562573,
-        "narHash": "sha256-4t1gdbChQ9kOq3ahPZtfF9s/xZmudLsOzEk+K2m+AAU=",
+        "lastModified": 1701957584,
+        "narHash": "sha256-xEpFaRdrneHl3Xdyzp3emd4QVxML7AR3GC91wuWi0Ok=",
         "owner": "numtide",
         "repo": "nixpkgs-unfree",
-        "rev": "730924907cecb6d5706d53766876e44ff3e11242",
+        "rev": "127b9b18583de04c6207c2a0e674abf64fc4a3b1",
         "type": "github"
       },
       "original": {
@@ -285,13 +286,46 @@
         "type": "github"
       }
     },
-    "utils": {
+    "systems_2": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {

--- a/home/roles/desktop/default.nix
+++ b/home/roles/desktop/default.nix
@@ -6,9 +6,7 @@ let
     RemoteCommand = "tmux new-session -A -s ssh_tmux";
   };
 in {
-  home.packages = with pkgs; [
-    obsidian
-  ];
+  home.packages = with pkgs; [ ];
 
   # SSH client related stuff here, I only want this on paddys (laptop)
   services.ssh-agent.enable = true;

--- a/hosts/dee/configuration.nix
+++ b/hosts/dee/configuration.nix
@@ -1,4 +1,4 @@
-{ argononed, config, pkgs, lib, ... }:
+{ argononed, catalog, config, pkgs, lib, ... }:
 let
 
   backupPaths = with lib;
@@ -119,6 +119,18 @@ in
   modules.plex.enable = true;
 
   services.prometheus.exporters.zfs.enable = true;
+
+  # dee does some extra forwarding to non-NixOS hosts, which are to be decommed
+  services.caddy.virtualHosts."proxmox.svc.joannet.casa".extraConfig = ''
+    tls {
+      dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+    }
+    reverse_proxy ${catalog.nodes.pve0.ip.private}:${toString catalog.services.proxmox.port} {
+      transport http {
+        tls_insecure_skip_verify
+      }
+    }
+  '';
 
   nix.buildMachines = [{
     hostName = "charlie";

--- a/modules/caddy/custom-caddy.nix
+++ b/modules/caddy/custom-caddy.nix
@@ -5,7 +5,7 @@
 stdenv.mkDerivation rec {
   pname = "caddy";
   # https://github.com/NixOS/nixpkgs/issues/113520
-  version = "2.7.5";
+  version = "2.7.6";
   dontUnpack = true;
 
   nativeBuildInputs = [ pkgs.git pkgs.go pkgs.xcaddy ];

--- a/modules/caddy/default.nix
+++ b/modules/caddy/default.nix
@@ -7,93 +7,6 @@ let
   cfg = config.modules.caddy;
 
   caddyMetricsPort = 2019;
-
-  routeHandler =
-    { port, upstream ? "localhost", skip_tls_verify ? false, path ? [ ] }:
-    let
-      base_handle = {
-        handler = "reverse_proxy";
-        upstreams = [{ dial = "${upstream}:${toString port}"; }];
-      };
-      handle = base_handle // optionalAttrs (skip_tls_verify) {
-        transport = {
-          protocol = "http";
-          tls.insecure_skip_verify = true;
-        };
-      };
-    in
-    {
-      handle = [ handle ];
-    } // optionalAttrs (length path > 0) { match = [{ path = path; }]; };
-
-  route =
-    { name
-    , port
-    , upstream ? "localhost"
-    , skip_tls_verify ? false
-    , paths ? [ ]
-    }:
-    let
-      subroutes = map (service: routeHandler service) (paths ++ [{
-        port = port;
-        upstream = upstream;
-        skip_tls_verify = skip_tls_verify;
-      }]);
-
-    in
-    {
-      match = [{ host = [ "${name}.svc.joannet.casa" ]; }];
-      terminal = true;
-      handle = [{
-        handler = "subroute";
-        routes = subroutes;
-      }];
-    };
-
-  # Filters out any services destined for this host, where we want it caddified
-  # TODO should it also depend whether the module is enabled or not?
-  host_services = attrValues (filterAttrs
-    (svc_name: svc_def:
-      svc_def ? "host" && svc_def.host.hostName == config.networking.hostName
-      && svc_def.caddify.enable)
-    catalog.services);
-
-  # Now feed them into the route function to construct a route entry
-  catalog_routes = map
-    (service:
-      route {
-        name = service.name;
-        port = service.port;
-        skip_tls_verify = service.caddify ? "skip_tls_verify"
-          && service.caddify.skip_tls_verify;
-        paths = optionals (service.caddify ? "paths") service.caddify.paths;
-      })
-    host_services;
-
-  # These are additional services that this host should forward
-  forward_services = attrValues (filterAttrs
-    (n: v:
-      v ? "caddify" && v.caddify ? "forwardTo" && v.caddify.enable
-      && v.caddify.forwardTo.hostName == config.networking.hostName)
-    catalog.services);
-
-  forward_routes = map
-    (service:
-      route {
-        name = service.name;
-        port = service.port;
-        upstream = service.host.ip.private;
-        skip_tls_verify = service.caddify ? "skip_tls_verify"
-          && service.caddify.skip_tls_verify;
-        # Not supporting paths yet since I don't have a scenario to test it on
-      })
-    forward_services;
-
-  combined_routes = catalog_routes ++ forward_routes;
-
-  subject_names = map (service: "${service.name}.svc.joannet.casa")
-    (host_services ++ forward_services);
-
 in
 {
 
@@ -123,44 +36,6 @@ in
       package = (pkgs.callPackage ./custom-caddy.nix {
         plugins = [ "github.com/caddy-dns/cloudflare" ];
       });
-      adapter = "''";
-      # https://github.com/NixOS/nixpkgs/issues/153142
-      configFile = pkgs.writeText "Caddyfile" (builtins.toJSON {
-        logging.logs.default.level = "ERROR";
-        # tried to get admin (and therefore metrics) exported externally but couldn't do so
-        #admin = {
-        #  listen = ":2019";
-        #  enforce_origin = false;
-        #};
-        apps = {
-          http.servers.srv0 = {
-            listen = [ ":443" ];
-            routes = combined_routes;
-            #metrics = {};
-          };
-          tls.automation.policies = [{
-            subjects = subject_names;
-            issuers = [
-              {
-                module = "acme";
-                ca = "https://acme-v02.api.letsencrypt.org/directory";
-                challenges.dns.provider = {
-                  name = "cloudflare";
-                  api_token = "{env.CLOUDFLARE_API_TOKEN}";
-                };
-              }
-              {
-                module = "zerossl";
-                ca = "https://acme-v02.api.letsencrypt.org/directory";
-                challenges.dns.provider = {
-                  name = "cloudflare";
-                  api_token = "{env.CLOUDFLARE_API_TOKEN}";
-                };
-              }
-            ];
-          }];
-        };
-      });
     };
 
     systemd.services.caddy = {
@@ -172,8 +47,5 @@ in
         TimeoutStartSec = "5m";
       };
     };
-
   };
-
 }
-

--- a/modules/dashy/default.nix
+++ b/modules/dashy/default.nix
@@ -99,6 +99,13 @@ in
 
   config = mkIf cfg.enable {
 
+    services.caddy.virtualHosts."home.svc.joannet.casa".extraConfig = ''
+      tls {
+        dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+      }
+      reverse_proxy localhost:${toString catalog.services.home.port}
+    '';
+
     virtualisation.oci-containers.containers.dashy = {
       image = "lissy93/dashy:${version}";
       volumes = [ "${configFile}:/app/public/conf.yml" ];

--- a/modules/healthchecks/default.nix
+++ b/modules/healthchecks/default.nix
@@ -28,6 +28,13 @@ in {
       group = "healthchecks";
     };
 
+    services.caddy.virtualHosts."healthchecks.svc.joannet.casa".extraConfig = ''
+      tls {
+        dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+      }
+      reverse_proxy localhost:${toString catalog.services.healthchecks.port}
+    '';
+
     services.healthchecks = {
       enable = true;
       port = catalog.services.healthchecks.port;

--- a/modules/minio/default.nix
+++ b/modules/minio/default.nix
@@ -18,6 +18,19 @@ in {
     age.secrets."minio-root-credentials".file =
       ../../secrets/minio-root-credentials.age;
 
+    services.caddy.virtualHosts."minio.svc.joannet.casa".extraConfig = ''
+      tls {
+        dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+      }
+      reverse_proxy localhost:${toString catalog.services.minio.port}
+    '';
+    services.caddy.virtualHosts."ui.minio.svc.joannet.casa".extraConfig = ''
+      tls {
+        dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+      }
+      reverse_proxy localhost:${toString catalog.services.minio.consolePort}
+    '';
+
     services.minio = {
       enable = true;
       dataDir = [ cfg.dataDir ];

--- a/modules/plex/default.nix
+++ b/modules/plex/default.nix
@@ -9,6 +9,13 @@ in {
 
   config = mkIf cfg.enable {
 
+    services.caddy.virtualHosts."plex.svc.joannet.casa".extraConfig = ''
+      tls {
+        dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+      }
+      reverse_proxy localhost:32400
+    '';
+
     services.plex = {
       enable = true;
       openFirewall = true;

--- a/modules/prometheus-stack/default.nix
+++ b/modules/prometheus-stack/default.nix
@@ -14,6 +14,29 @@ in {
 
   config = mkIf cfg.enable {
 
+   services.caddy.virtualHosts = {
+     "grafana.svc.joannet.casa".extraConfig = ''
+       tls {
+         dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+       }
+       reverse_proxy localhost:${toString catalog.services.grafana.port}
+     '';
+     "loki.svc.joannet.casa".extraConfig = ''
+       tls {
+         dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+       }
+       reverse_proxy localhost:${toString catalog.services.loki.port}
+     '';
+     "victoriametrics.svc.joannet.casa" = mkIf cfg.victoriametrics.enable {
+        extraConfig = ''
+          tls {
+            dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+          }
+          reverse_proxy localhost:${toString catalog.services.victoriametrics.port}
+        '';
+      };
+    };
+
     networking.firewall.allowedTCPPorts = [
       # TODO are all these still required after being fronted by local reverse proxy?
       config.services.grafana.settings.server.http_port

--- a/modules/prometheus-stack/grafana.nix
+++ b/modules/prometheus-stack/grafana.nix
@@ -168,7 +168,7 @@
                   relativeTimeRange.to = 0;
                   model = {
                     refId = "A";
-                    expr = "count_over_time({host=~\".+\", unit!=\"loki.service\"} |= \"Failed with result\" | regexp \"(?P<service>.*): Failed with result ''(?P<result>.*)''.\" [5m])";
+                    expr = "count_over_time({host=~\".+\", unit!~\"(loki|grafana).service\"} |= \"Failed with result\" | regexp \"(?P<service>.*): Failed with result ''(?P<result>.*)''.\" [5m])";
                     hide = false;
                     interval = 1000;
                     maxDataPoints = 43200;

--- a/modules/prometheus-stack/scrape-configs.nix
+++ b/modules/prometheus-stack/scrape-configs.nix
@@ -6,8 +6,13 @@ let
   nodeExporterTargets =
     map (node_name: "${node_name}.joannet.casa") (attrNames catalog.nodes);
 
+  # Support both old and new method
+  shouldDNS = service:
+    (service ? "caddify" && service.caddify ? "enable" && service.caddify.enable) ||
+    (service ? "dns" && service.dns ? "enable" && service.dns.enable);
+
   caddified_services = attrValues (filterAttrs
-    (svc_name: svc_def: svc_def ? "caddify" && svc_def.caddify.enable)
+    (svc_name: svc_def: shouldDNS svc_def)
     catalog.services);
 
   internal_https_targets =

--- a/modules/unifi/default.nix
+++ b/modules/unifi/default.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, catalog, pkgs, lib, ... }:
 
 with lib;
 
@@ -10,6 +10,17 @@ in {
   };
 
   config = mkIf cfg.enable {
+
+    services.caddy.virtualHosts."unifi.svc.joannet.casa".extraConfig = ''
+      tls {
+        dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+      }
+      reverse_proxy localhost:${toString catalog.services.unifi.port} {
+        transport http {
+          tls_insecure_skip_verify
+        }
+      }
+    '';
 
     # If doing a fresh install then you may need to open 8443
     # temporarily before you can close it out again


### PR DESCRIPTION
This PR untangles how Caddy config gets built on each node that hosts a service. Instead of building the config in the caddy module, the config is now built in the service modules that require it. There would be a disconnect on whether we needed to build a Caddy config for a service, even if the module was disabled. This is a better Nix approach.

A lot of how this used to work is documented in this [blog post](https://jdheyburn.co.uk/blog/automating-service-configurations-with-nixos/). I'll do a follow up one at some point on how this PR works.

I also made some changes including how Prometheus scrape configs are pulled (albeit in the same manner as above), and some other minor stuff.