### PR TITLE
Migrate dashy to charlie

### DIFF
--- a/catalog.nix
+++ b/catalog.nix
@@ -102,7 +102,7 @@
     };
 
     home = {
-      host = nodes.dennis;
+      host = nodes.charlie;
       port = 4000;
       blackbox.name = "dashy";
       dns.enable = true;

--- a/hosts/charlie/configuration.nix
+++ b/hosts/charlie/configuration.nix
@@ -25,6 +25,7 @@
   ## Modules
   ###############################################################################
 
+  modules.caddy.enable = true;
   modules.dashy.enable = true;
   modules.monitoring.enable = true;
   modules.nfs-client.enable = true;

--- a/hosts/charlie/configuration.nix
+++ b/hosts/charlie/configuration.nix
@@ -25,6 +25,7 @@
   ## Modules
   ###############################################################################
 
+  modules.dashy.enable = true;
   modules.monitoring.enable = true;
   modules.nfs-client.enable = true;
 

--- a/modules/dashy/default.nix
+++ b/modules/dashy/default.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  version = "3.1.1";
+  version = "release-3.1.1";
 
   cfg = config.modules.dashy;
 
@@ -98,18 +98,19 @@ in
   options.modules.dashy = { enable = mkEnableOption "enable dashy"; };
 
   config = mkIf cfg.enable {
-
     services.caddy.virtualHosts."home.svc.joannet.casa".extraConfig = ''
       tls {
         dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+        # Below required to get TLS to work on non-local hosts (i.e. charlie)
+        resolvers 8.8.8.8
       }
       reverse_proxy localhost:${toString catalog.services.home.port}
     '';
 
     virtualisation.oci-containers.containers.dashy = {
       image = "lissy93/dashy:${version}";
-      volumes = [ "${configFile}:/app/public/conf.yml" ];
-      ports = [ "${toString catalog.services.home.port}:80" ];
+      volumes = [ "${configFile}:/app/user-data/conf.yml" ];
+      ports = [ "${toString catalog.services.home.port}:8080" ];
     };
   };
 }

--- a/modules/dns/default.nix
+++ b/modules/dns/default.nix
@@ -16,7 +16,7 @@ let
   service_rewrites = map
     (service: {
       domain = "${service.name}.svc.joannet.casa";
-      answer = service.host.ip.private;
+      answer = if service.host.ip ? "private" then service.host.ip.private else service.host.ip.tailscale;
     })
     caddy_services;
   # Add rewrites for any node that has a domain


### PR DESCRIPTION
Dennis is decommissioned so use charlie instead

First time getting caddy to work on a server that isn't in my local network (charlie is a Hetzner VPS which is accessed via tailnet), so I had to add a [tls.resolvers](https://caddyserver.com/docs/caddyfile/directives/tls#resolvers) config as per this [thread](https://caddy.community/t/caddy-cloudflare-seems-to-be-trying-to-register-against-net/19206/3) on caddy forums. I was getting the same error but for `.casa`.

Had to also modify DNS rewrite to refer rewriting to local IP network first if the node has the IP, otherwise default to tailscale IP, as is the case with charlie.