### PR TITLE
Refactor DNS and blackbox checks

### DIFF
--- a/catalog.nix
+++ b/catalog.nix
@@ -75,7 +75,7 @@
     actual = {
       host = nodes.dee;
       port = 5006;
-      dns.enable = true;
+      modules = [ "actualbudget" ];
     };
 
     adguard = {
@@ -84,12 +84,12 @@
       dashy.section = "networks";
       dashy.description = "DNS resolver";
       dashy.icon = "hl-adguardhome";
-      dns.enable = true;
+      modules = [ "dns" ];
     };
 
     aria2 = {
       host = nodes.dee;
-      dns.enable = true;
+      modules = [ "aria2" ];
     };
 
     blackboxExporter = { port = 9115; };
@@ -100,21 +100,20 @@
       dashy.section = "monitoring";
       dashy.description = "Monitor status of cron jobs";
       dashy.icon = "hl-healthchecks";
-      dns.enable = true;
+      modules = [ "healthchecks" ];
     };
 
     home = {
       host = nodes.charlie;
       port = 4000;
       blackbox.name = "dashy";
-      dns.enable = true;
+      modules = [ "dashy" ];
     };
 
     huginn = {
       host = nodes.frank;
       port = 3000;
       dashy.icon = "hl-huginn";
-      dns.enable = false;
     };
 
     grafana = {
@@ -123,14 +122,14 @@
       dashy.section = "monitoring";
       dashy.description = "View logs and metrics";
       dashy.icon = "hl-grafana";
-      dns.enable = true;
+      modules = [ "prometheusStack" "prometheusStack.grafana" ];
     };
 
     loki = {
       host = nodes.charlie;
       port = 3100;
       blackbox.path = "/ready";
-      dns.enable = true;
+      modules = [ "prometheusStack" "prometheusStack.loki" ];
     };
 
     nodeExporter = { port = 9002; };
@@ -139,7 +138,7 @@
       host = nodes.dee;
       port = 9100;
       consolePort = 9101;
-      dns.enable = true;
+      modules = [ "minio" ];
     };
 
     "ui.minio" = {
@@ -148,7 +147,7 @@
       dashy.section = "storage";
       dashy.description = "S3 compatible object storage";
       dashy.icon = "hl-minio";
-      dns.enable = true;
+      modules = [ "minio" ];
     };
 
     portainer = {
@@ -157,7 +156,6 @@
       dashy.section = "virtualisation";
       dashy.description = "Frontend for containers";
       dashy.icon = "hl-portainer";
-      dns.enable = false;
     };
 
     prometheus = {
@@ -166,7 +164,6 @@
       dashy.section = "monitoring";
       dashy.description = "Polls for metrics before captured by Thanos";
       dashy.icon = "hl-prometheus";
-      dns.enable = false;
     };
 
     promtail = { port = 28183; };
@@ -177,7 +174,6 @@
       dashy.section = "virtualisation";
       dashy.description = "Frontend for VMs";
       dashy.icon = "hl-proxmox";
-      dns.enable = false;
     };
 
     plex = {
@@ -186,7 +182,7 @@
       dashy.section = "media";
       dashy.description = "Watch TV and movies";
       dashy.icon = "hl-plex";
-      dns.enable = true;
+      modules = [ "plex" ];
     };
 
     thanos-query = {
@@ -196,7 +192,6 @@
       dashy.section = "monitoring";
       dashy.description = "Long term storage for Prometheus metrics";
       dashy.icon = "hl-thanos";
-      dns.enable = false;
     };
 
     thanos-sidecar = {
@@ -215,7 +210,7 @@
       dashy.section = "networks";
       dashy.description = "UniFi controller";
       dashy.icon = "hl-unifi-controller";
-      dns.enable = true;
+      modules = [ "unifi" ];
     };
 
     victoriametrics = {
@@ -224,7 +219,7 @@
       dashy.section = "monitoring";
       dashy.description = "Alternate poller of metrics in PromQL format";
       dashy.icon = "https://avatars.githubusercontent.com/u/43720803";
-      dns.enable = true;
+      modules = [ "prometheusStack" "prometheusStack.victoriametrics" ];
     };
   };
 

--- a/modules/dns/default.nix
+++ b/modules/dns/default.nix
@@ -1,11 +1,21 @@
-{ catalog, config, pkgs, lib, ... }:
+{ catalog, config, flake-self, pkgs, lib, ... }:
 
 with lib;
 
 let
   cfg = config.modules.dns;
 
-  shouldDNS = service: service ? "dns" && service.dns ? "enable" && service.dns.enable;
+  isEnabled = moduleName: hostName:
+    let
+      parts = splitString "." moduleName;
+      module = builtins.foldl' (acc: part: builtins.getAttr part acc) flake-self.nixosConfigurations."${hostName}".config.modules parts;
+    in
+    module.enable;
+
+  shouldDNS = service:
+    # Only create DNS entries if the host that catalog.service says its running on has it enabled
+    # service.modules is a list of strings that contain paths to check for enabling, see catalog.nix
+    service ? "modules" && (all (x: x) (map (moduleName: isEnabled moduleName service.host.hostName) service.modules));
 
   # Get services which are being served by caddy
   caddy_services = attrValues (filterAttrs

--- a/modules/prometheus-stack/victoria-metrics.nix
+++ b/modules/prometheus-stack/victoria-metrics.nix
@@ -1,4 +1,4 @@
-{ catalog, config, pkgs, lib, ... }:
+{ catalog, config, flake-self, pkgs, lib, ... }:
 
 with lib;
 
@@ -26,7 +26,7 @@ in {
     services.victoriametrics = {
       enable = true;
       #package = pkgs.victoriametrics-enterprise;
-      prometheusConfig.scrape_configs = import ./scrape-configs.nix { inherit catalog config lib; };
+      prometheusConfig.scrape_configs = import ./scrape-configs.nix { inherit catalog config flake-self lib; };
       #extraOptions = [ "-licenseFile=${config.age.secrets."victoriametrics-license".path}" ];
       extraOptions = [ "-selfScrapeInterval=10s" ];
     };


### PR DESCRIPTION
Instead of having a hardcoded `dns.enable` attribute on the catalog services, it can be made dynamic.

Since we specify the node that the service runs on, we can check to see if its enabled on there before deciding what to do with that information (i.e. create DNS rewrite entry, blackbox healthchecks).

So `dns.enable` is replaced with a list of strings called `modules`:

```nix
host = nodes.someHost;
modules = [ "service" "service.nested" ]; 
````

This is then looked up in the nixosConfigurations for someHost to see if both `modules.service.enable` and `modules.service.nested.enable` are true. All paths in the modules have to be true for it to be created.

The logic used is below:

```nix
  isEnabled = moduleName: hostName:
    let
      parts = splitString "." moduleName;
      module = builtins.foldl' (acc: part: builtins.getAttr part acc) flake-self.nixosConfigurations."${hostName}".config.modules parts;
    in
    module.enable;

  shouldDNS = service:
    # Only create DNS entries if the host that catalog.service says its running on has it enabled
    # service.modules is a list of strings that contain paths to check for enabling, see catalog.nix
    service ? "modules" && (all (x: x) (map (moduleName: isEnabled moduleName service.host.hostName) service.modules));

```

The `builtins.foldl'` part is some gnarly logic that ChatGPT got for me, I couldn't tell you exactly how it works but it does what I need.