### PR TITLE
Tmux prefix works now

### DIFF
--- a/hosts/darwin/common/default.nix
+++ b/hosts/darwin/common/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, primaryUser, ... }: {
+{ lib, pkgs, primaryUser, config, ... }: {
 
   # Required in newer nix-darwin
   system.stateVersion = 4;
@@ -14,21 +14,20 @@
   nix.gc.options = "--delete-older-than 30d";
   nix.optimise.automatic = false;
 
-  # Below option has been removed from nix-darwin, keeping it here for reference
-  # system.activationScripts.postUserActivation = {
-  #   text = ''
-  #     # Show diff after switch - https://gist.github.com/luishfonseca/f183952a77e46ccd6ef7c907ca424517
-  #     # Fresh systems won't have /run/current-system
-  #     if [ -d /run/current-system ]; then
-  #       ${pkgs.nvd}/bin/nvd --nix-bin-dir=${pkgs.nix}/bin diff /run/current-system "$systemConfig"
-  #     fi
+  system.activationScripts.postActivation = {
+    text = ''
+      # Show diff after switch - https://gist.github.com/luishfonseca/f183952a77e46ccd6ef7c907ca424517
+      # Fresh systems won't have /run/current-system
+      if [ -d /run/current-system ]; then
+        ${pkgs.nvd}/bin/nvd --nix-bin-dir=${pkgs.nix}/bin diff /run/current-system "$systemConfig"
+      fi
 
-  #     # Activate new macOS settings immediately,
-  #     /System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
-  #   '';
-  # } // lib.optionalAttrs pkgs.stdenv.isLinux {
-  #   supportsDryActivation = true;
-  # };
+      # Activate new macOS settings immediately,
+      sudo -u ${config.system.primaryUser} /System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
+    '';
+  } // lib.optionalAttrs pkgs.stdenv.isLinux {
+    supportsDryActivation = true;
+  };
 
   # Needs to be duplicated here, even though it is defined in home-manager too
   programs.zsh.enable = true;
@@ -70,6 +69,14 @@
     CustomUserPreferences = {
       "com.apple.symbolichotkeys" = {
         AppleSymbolicHotKeys = {
+          "60" = {
+            # Disable '^ + Space' for selecting the previous input source
+            enabled = false;
+          };
+          "61" = {
+            # Disable '^ + Option + Space' for selecting the next input source
+            enabled = false;
+          };
           # Disable 'Cmd + Space' for Spotlight Search
           "64" = {
             enabled = false;


### PR DESCRIPTION
My tmux prefix `C+Space` wasn't working. There is a macOS shortcut that intercepts this,so that needs to be disabled.

Also got post activation working again, the latest change had removed the ability to do this on a user level, so the setting needs to be done on a root level.