### PR TITLE
Migrate media restic repo to cloud

### DIFF
--- a/hosts/nixos/dee/configuration.nix
+++ b/hosts/nixos/dee/configuration.nix
@@ -82,7 +82,10 @@
     prune = true;
   };
 
-  modules.backup.usb.enable = true;
+  modules.backup.usb = {
+    enable = true;
+    rcloneConfigFile = config.age.secrets."rclone.conf".path;
+  };
   modules.caddy.enable = true;
   modules.dns.enable = true;
   modules.healthchecks.enable = true;

--- a/modules/backup/usb.nix
+++ b/modules/backup/usb.nix
@@ -27,7 +27,7 @@ in
 
       services.restic.backups.media = {
         repository = "rclone:b2:iifu8Noi-backups/restic/media";
-        rcloneConfigFile = config.rcloneConfigFile;
+        rcloneConfigFile = cfg.rcloneConfigFile;
         passwordFile = config.age.secrets."restic-media-password".path;
         pruneOpts = [
           "--keep-daily 30"

--- a/modules/backup/usb.nix
+++ b/modules/backup/usb.nix
@@ -16,6 +16,8 @@ in
 
   options.modules.backup.usb = {
     enable = mkEnableOption "Enable backup of media and rclone to cloud";
+
+    rcloneConfigFile = mkOption { type = types.path; };
   };
 
   config = mkIf cfg.enable
@@ -24,7 +26,8 @@ in
         ../../secrets/restic-media-password.age;
 
       services.restic.backups.media = {
-        repository = "/mnt/nfs/restic/media";
+        repository = "rclone:b2:iifu8Noi-backups/restic/media";
+        rcloneConfigFile = config.rcloneConfigFile;
         passwordFile = config.age.secrets."restic-media-password".path;
         pruneOpts = [
           "--keep-daily 30"
@@ -68,9 +71,6 @@ in
 
           echo "rcloning vinyl -> gdrive:media/vinyl"
           ${pkgs.rclone}/bin/rclone -v sync /mnt/nfs/media/vinyl gdrive:media/vinyl --config=$RCLONE_CONF_PATH
-
-          echo "rcloning restic/media -> b2:restic/media"
-          ${pkgs.rclone}/bin/rclone -v sync /mnt/nfs/restic/media b2:iifu8Noi-backups/restic/media --config=$RCLONE_CONF_PATH
 
           echo "rcloning minio -> b2:minio"
           ${pkgs.rclone}/bin/rclone -v sync minio: b2:iifu8Noi-backups/minio --config=$RCLONE_CONF_PATH


### PR DESCRIPTION
My local HDD is running out of space. I had a local copy of the restic backups for my media directory which gets synced to B2. It's running at about 500 GiB so I can reclaim some space by bypassing local write to HDD and backing up straight to B2.

